### PR TITLE
feat: 添加代码抽象语法树（CST）支持

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,19 @@
       "version": "0.0.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@babel/parser": "^7.27.0",
         "axios": "^1.8.4",
         "lru-cache": "^11.1.0",
+        "node-addon-loader": "^0.0.6",
         "openai": "^4.95.1",
         "prettier": "^3.5.3",
-        "tree-sitter": "^0.22.4"
+        "python-ast": "^0.1.0",
+        "python-parser": "^1.0.3",
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-c": "^0.20.7",
+        "tree-sitter-cpp": "^0.23.2",
+        "tree-sitter-javascript": "^0.23.1",
+        "tree-sitter-python": "^0.23.3"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -61,6 +69,52 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmmirror.com/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmmirror.com/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -1252,6 +1306,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/antlr4": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmmirror.com/antlr4/-/antlr4-4.13.1.tgz",
+      "integrity": "sha512-kiXTspaRYvnIArgE97z5YVVf/cDVQABr3abFRR6mE7yesLMkgu4ujuyV/sgxafQ8wgve0DJQUJ38Z8tkgA2izA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/antlr4ts": {
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmmirror.com/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -1382,6 +1451,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmmirror.com/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1980,6 +2058,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
@@ -3669,6 +3756,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -3730,6 +3829,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmmirror.com/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -3884,6 +3997,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -4092,6 +4214,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmmirror.com/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4108,11 +4236,20 @@
     },
     "node_modules/node-addon-api": {
       "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/node-addon-api/-/node-addon-api-8.3.1.tgz",
       "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-addon-loader": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmmirror.com/node-addon-loader/-/node-addon-loader-0.0.6.tgz",
+      "integrity": "sha512-1qfu2CuHBdqPMmNb/q913madmxZg2A9MHt0bcRfWQQrpqQ9NptOBrXO4wrW4DrpofnsCoIbZf5QI1gYTZ02XwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^1.1.0"
       }
     },
     "node_modules/node-domexception": {
@@ -4157,7 +4294,7 @@
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "resolved": "https://registry.npmmirror.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
       "bin": {
@@ -4882,6 +5019,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/python-ast": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/python-ast/-/python-ast-0.1.0.tgz",
+      "integrity": "sha512-uMPE7HRMfsbHtQYPg/+EH9MJkynLfLr+0VJbeBgJHpt2wuDgf5hZrEczOIGNFKaO0W1HWiL7bSxA/EOOo70mIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "antlr4ts": "^0.5.0-alpha.3"
+      }
+    },
+    "node_modules/python-parser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/python-parser/-/python-parser-1.0.3.tgz",
+      "integrity": "sha512-CjNc09lZr5ezmcW7J2r93Olk+hhAMIr/W2i8wugYj4gpaVly0rf4iEmSapk9CMZDzQAgWmQVzq/W15A+EWN2WA==",
+      "dependencies": {
+        "antlr4": "4.13.1"
       }
     },
     "node_modules/queue-microtask": {
@@ -5767,14 +5921,81 @@
       "license": "MIT"
     },
     "node_modules/tree-sitter": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
-      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmmirror.com/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-c": {
+      "version": "0.20.7",
+      "resolved": "https://registry.npmmirror.com/tree-sitter-c/-/tree-sitter-c-0.20.7.tgz",
+      "integrity": "sha512-T8m3hT4EAHfwFl0uSuQbYM2zImjs5njp+wIfwB8a0g0BMAlFkzdPAUomuNrKBvvMRYkhe4YMpK3r4tV+UPm/aw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.18.0"
+      }
+    },
+    "node_modules/tree-sitter-cpp": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmmirror.com/tree-sitter-cpp/-/tree-sitter-cpp-0.23.2.tgz",
+      "integrity": "sha512-GTa5Dx1O9ihzW70LvaUviTclh+wlBDRz6opR9Ij4NQIFmq/joeZ/k65UbLV4nLidR7xZ9eNNGT/SonCqAmjGVg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmmirror.com/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-python": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmmirror.com/tree-sitter-python/-/tree-sitter-python-0.23.3.tgz",
+      "integrity": "sha512-QtxZBwFllhS2XXX3zMwsWhAajMZ36h6rD0TuV1fmNifBI3vqEW8QcXwvzotipdMe6zZiDSZRLezSTl01KVlcfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -51,10 +51,18 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@babel/parser": "^7.27.0",
     "axios": "^1.8.4",
     "lru-cache": "^11.1.0",
+    "node-addon-loader": "^0.0.6",
     "openai": "^4.95.1",
     "prettier": "^3.5.3",
-    "tree-sitter": "^0.22.4"
+    "python-ast": "^0.1.0",
+    "python-parser": "^1.0.3",
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-c": "^0.20.7",
+    "tree-sitter-cpp": "^0.23.2",
+    "tree-sitter-javascript": "^0.23.1",
+    "tree-sitter-python": "^0.23.3"
   }
 }

--- a/src/core/context/codeCST.ts
+++ b/src/core/context/codeCST.ts
@@ -1,0 +1,53 @@
+import * as vscode from "vscode";
+import Parser from "tree-sitter";
+import { CURSOR_HOLDER } from "../../globalConst";
+import { spawn, spawnSync } from "child_process";
+
+export interface CodeCST {
+  tree: Parser.Tree | undefined,
+}
+
+export function getCodeCST(editor: vscode.TextEditor | undefined,
+  ): Promise<CodeCST> {
+  return new Promise<CodeCST>(async () => {
+    const editor = vscode.window.activeTextEditor;
+    if(editor){
+        const code = editor.document.getText();
+        const fileName = editor.document.fileName;
+    
+        // npm install tree-sitter@0.21.1
+        const Parser = require("tree-sitter");
+        const parser = new Parser();
+
+        if(fileName.endsWith(".js") || fileName.endsWith(".ts")){
+            // npm install tree-sitter-javascript@0.23.1
+            const JavaScript = require("tree-sitter-javascript");
+            parser.setLanguage(JavaScript);
+        }else if(fileName.endsWith(".py")){
+            // npm install tree-sitter-python@0.23.3
+            const Python = require("tree-sitter-python");
+            parser.setLanguage(Python);
+        }else if(fileName.endsWith(".cpp")){
+            // npm install tree-sitter-cpp@0.23.2
+            const Cpp = require("tree-sitter-cpp");
+            parser.setLanguage(Cpp);
+        }else if(fileName.endsWith(".c")){
+            // npm install tree-sitter-c@0.20.7
+            // C source code can't be parsed currently.
+            const C = require("tree-sitter-c");
+            parser.setLanguage(C);
+        }
+        const tree = parser.parse(code);
+        console.log('-----------------------------------');
+        console.log(code);
+        console.log('**********');
+        console.log(tree.rootNode.toString());
+
+        return {
+            tree,
+        };
+    }
+
+    return { tree: null };
+  });
+}

--- a/src/core/control.ts
+++ b/src/core/control.ts
@@ -6,12 +6,14 @@ import {
 } from "./cache/cache";
 import * as vscode from "vscode";
 import { CodeContext, getCodeContext } from "./context/codeContext";
+import { CodeCST, getCodeCST } from "./context/codeCST";
 import { CURSOR_HOLDER, RAW_SNIPPET } from "../globalConst";
 import { Hasher } from "./cache/hash";
 import { insertCode } from "./insert/insert";
 
 interface ControllSession {
   ctx: CodeContext;
+  cst: CodeCST;
   hashKey: string;
   cancel: boolean;
   needRequest: boolean;
@@ -37,15 +39,16 @@ export class FIMController {
    * @returns 应返回一个上下文对象，为了简洁，复用传入的session对象
    */
   async getCtx(session: ControllSession) {
-    session.ctx = await getCodeContext(this.editor);
+    session.cst = await getCodeCST(this.editor);
     // 以下是debug信息
-    const mid =
-      session.ctx.middle.slice(0, session.ctx.cursor.col) +
-      CURSOR_HOLDER +
-      session.ctx.middle.slice(session.ctx.cursor.col);
-    const fullCode =
-      session.ctx.prefix + "\n" + mid + "\n" + session.ctx.suffix;
-    console.log(fullCode);
+    // const mid =
+    //   session.ctx.middle.slice(0, session.ctx.cursor.col) +
+    //   CURSOR_HOLDER +
+    //   session.ctx.middle.slice(session.ctx.cursor.col);
+    // const fullCode =
+    //   session.ctx.prefix + "\n" + mid + "\n" + session.ctx.suffix;
+    // console.log(fullCode);
+    console.log(session.cst.tree?.rootNode.toString());
   }
   /**
    * 此函数主要为会话对象附上配置信息
@@ -111,6 +114,9 @@ export class FIMController {
           line: 0,
           col: 0,
         },
+      },
+      cst: {
+        tree: undefined,
       },
       hashKey: "",
       cancel: false,


### PR DESCRIPTION
使用了tree-sitter来生成各种源代码的CST。

- 目前存在一个**严重问题**：tree-sitter中似乎没有对esbuild的依赖导致插件在启动时esbuild会报错，导致无法插件无法正常运行。当不使用esbuild时插件即可正常运行（在另外的一个环境进行测试的）。

- 目前CST支持对javascript, c++, python源代码的识别，c的不知为何暂时无法运行。

- 由于不同的语言类型需要的tree-sitter版本可能不一致，在安装tree-sitter的语言包时最好按照注释所写的来安装（随便试的一套，至少能跑）。
